### PR TITLE
Reference upstream FastVLM demo asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # blueeyes
-fastvllm container for image and video inferencing
+
+FastVLM container for image and video inferencing.
+
+## Demo asset
+
+The container no longer vendors the demo image at `assets/demo.jpg`. Instead,
+the startup script expects the upstream `apple/ml-fastvlm` repository to be
+available (for example at `/opt/apple/ml-fastvlm`) and reuses the demo asset
+shipped there at `assets/demo.jpg`. The resolved path is exposed to downstream
+processes via the `BLUEEYES_DEMO_ASSET` environment variable.
+
+Use `scripts/start.sh` to bootstrap the container environment; the script will
+validate the upstream asset path before running the requested command.

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Entrypoint for launching the FastVLM demo inside the blueeyes container.
+#
+# The image demo asset used by the notebook/UI is no longer vendored in this
+# repository. Instead, we rely on the copy that ships with the upstream
+# apple/ml-fastvlm repository under `assets/demo.jpg`.
+set -euo pipefail
+
+FASTVLM_ROOT=${FASTVLM_ROOT:-/opt/apple/ml-fastvlm}
+UPSTREAM_DEMO_RELATIVE="assets/demo.jpg"
+UPSTREAM_DEMO_ASSET="${FASTVLM_ROOT}/${UPSTREAM_DEMO_RELATIVE}"
+
+if [[ ! -f "${UPSTREAM_DEMO_ASSET}" ]]; then
+  cat <<EOM >&2
+[blueeyes] Unable to find the upstream demo asset at:
+  ${UPSTREAM_DEMO_ASSET}
+Please make sure the apple/ml-fastvlm repository is available in the
+container (or mount it) so that the demo image can be served.
+EOM
+  exit 1
+fi
+
+export BLUEEYES_DEMO_ASSET="${UPSTREAM_DEMO_ASSET}"
+
+if [[ $# -eq 0 ]]; then
+  exec bash
+else
+  exec "$@"
+fi


### PR DESCRIPTION
## Summary
- document that the local demo image has been removed and that we reuse the asset from the apple/ml-fastvlm repository
- add a startup helper script that resolves the upstream demo asset path and exports it for downstream processes

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dece579aa8832598fe9e3dc38185d3